### PR TITLE
Re-enable scheduler

### DIFF
--- a/app/etl/scheduler.py
+++ b/app/etl/scheduler.py
@@ -7,7 +7,7 @@ class Scheduler:
     def __init__(self, populate_database_task):
         self.scheduler = BackgroundScheduler()
         self.scheduler.add_job(
-            populate_database_task.delay, 'cron', hour='0',
+            populate_database_task, 'cron', hour='0',
         )
         atexit.register(lambda: self.scheduler.shutdown(wait=False))
 

--- a/app/worker.py
+++ b/app/worker.py
@@ -1,9 +1,10 @@
+from app.api.tasks import populate_database_task
 from app.application import get_or_create
 from app.etl.scheduler import Scheduler
-from app.api.tasks import populate_database_task
 
 app = get_or_create()
 celery_app = app.celery
 
-scheduled_task = Scheduler(populate_database_task)
-scheduled_task.start()
+if app.config['app']['run_scheduler']:
+    scheduled_task = Scheduler(populate_database_task)
+    scheduled_task.start()

--- a/app/worker.py
+++ b/app/worker.py
@@ -1,4 +1,9 @@
 from app.application import get_or_create
+from app.etl.scheduler import Scheduler
+from app.api.tasks import populate_database_task
 
 app = get_or_create()
 celery_app = app.celery
+
+scheduled_task = Scheduler(populate_database_task)
+scheduled_task.start()


### PR DESCRIPTION
This re-enables the scheduler.
 - As it will runs on the celery worker I don't think it requires the delay
 - Unsure if we should just switch to celery beat and remove apscheduler (think we could do that a later date so don't need to do it now)