### PR TITLE
Feature/local config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ run_dev_server:
 run_tests:
 	TESTING=1 pytest -p no:sugar ${TEST} ${COV}
 
+
 .PHONY: run_tests_local
 run_tests_local:
 	USE_DOTENV=1 TESTING=1 pytest -s ${TEST}

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ run_dev_server:
 run_tests:
 	TESTING=1 pytest -p no:sugar ${TEST} ${COV}
 
+.PHONY: run_tests_local
+run_tests_local:
+	USE_DOTENV=1 TESTING=1 pytest -s ${TEST}
+
 
 .PHONY: check
 check: flake8 black

--- a/README.md
+++ b/README.md
@@ -25,17 +25,17 @@ Running postgres in docker now requires a mandatory environment variable called 
 
 ## Config
 
-## When using docker-compose
+### When using docker-compose
 Place environment variables in .env file.
 
-## When using host machine
+### When using host machine
 Config variables can be specified in a few ways and are loaded using the following order of priority:
 
-#### 1. Look for variable in existing System environment variables
-#### 2. If not found in step 1, look for variable in `.env` (this only works if USE_DOTENV is set to 1)
-#### 3. If not found in step 2, look for variable in `local_testing.yml` (this only works if TESTING is set to 1)
-#### 4. If not found in step 3, look for variable in `local.yml` (this only works if TESTING is set to 0)
-#### 5. If not found in step 4, look for variable in `default.yml`
+1. Look for variable in existing System environment variables
+2. If not found in step 1, look for variable in `.env` (this only works if USE_DOTENV is set to 1)
+3. If not found in step 2, look for variable in `local_testing.yml` (this only works if TESTING is set to 1)
+4. If not found in step 3, look for variable in `local.yml` (this only works if TESTING is set to 0)
+5. If not found in step 4, look for variable in `default.yml`
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The countries of interest service aims to provide insight into the countries tha
 to give the most informed view into a companies intereset in particular countries.
 
 ## Installation
-The backend is built in Python using the Flask framework. Authentication implemented using Hawk and OAUTH2(SSO) authentication. The majority of the functionality is through API calls but a light front end is provided for documentation and dashboarding. This front end uses React and d3 and uses the webpack javascript module bundler. 
+The backend is built in Python using the Flask framework. Authentication implemented using Hawk and OAUTH2(SSO) authentication. The majority of the functionality is through API calls but a light front end is provided for documentation and dashboarding. This front end uses React and d3 and uses the webpack javascript module bundler.
 
 ### local Docker installation
 1. Move your environment variables file to `$PROJECT_HOME/.env`
@@ -21,18 +21,35 @@ You can configure how `docker-compose` runs with environment variables,
 * change the environment file with the `ENV_FILE` environment variable
 * e.g. `PORT=8000 ENV_FILE=my_envs docker-compose build` and again when using `docker-compose up`
 
+Running postgres in docker now requires a mandatory environment variable called POSTGRES_PASSWORD. This must be added to your .env file.
+
+## Config
+
+## When using docker-compose
+Place environment variables in .env file.
+
+## When using host machine
+Config variables can be specified in a few ways and are loaded using the following order of priority:
+
+#### 1. Look for variable in existing System environment variables
+#### 2. If not found in step 1, look for variable in `.env` (this only works if USE_DOTENV is set to 1)
+#### 3. If not found in step 2, look for variable in `local_testing.yml` (this only works if TESTING is set to 1)
+#### 4. If not found in step 3, look for variable in `local.yml` (this only works if TESTING is set to 0)
+#### 5. If not found in step 4, look for variable in `default.yml`
+
 ## Testing
-From the project base directory use the command,
 
-`TESTING=1 pytest`
+Running tests locally
 
-to run tests for a specific test module, do,
+`make run_tests_local`
 
-`TESTING=1 pytest tests/<test_module>`
+to run tests for a specific directory, do,
 
-to run tests in a specific directory do,
+`make run_tests_local TEST=<tests/test_directory>`
 
-`TESTING=1 pytest tests/<test_directory>`
+Running tests the same way as circle ci:
+
+`make run_tests`
 
 ## Deployment
 
@@ -43,13 +60,13 @@ to run tests in a specific directory do,
 `cf v3-scale countries-of-interest-service -k 3G`
 
 ### create services
-`cf create-service postgres small-10 countries-of-interest-service-db`  
+`cf create-service postgres small-10 countries-of-interest-service-db`
 `cf create-service redis tiny-3.2 countries-of-interest-service-redis`
 
 once services and app have been created
 
 ### bind services
-`cf bind-service countries-of-interest-service countries-of-interest-service-db`  
+`cf bind-service countries-of-interest-service countries-of-interest-service-db`
 `cf bind-service countries-of-interest-service countries-of-interest-service-redis`
 
 ### deploy with vault environment variables

--- a/app/config/__init__.py
+++ b/app/config/__init__.py
@@ -3,8 +3,8 @@ import os
 import re
 from pathlib import Path
 
-from dotenv import load_dotenv
 import yaml
+from dotenv import load_dotenv
 
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 

--- a/app/config/__init__.py
+++ b/app/config/__init__.py
@@ -3,12 +3,17 @@ import os
 import re
 from pathlib import Path
 
+from dotenv import load_dotenv
 import yaml
 
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
 
 def get_config():
+    if bool(int(os.environ.get('USE_DOTENV', '0'))):
+        # Load environment variables from .env file, this does not
+        # override existing System environment variables
+        load_dotenv(override=False)
     default = _get_default_config()
     _parse_env_vars(default)
     local = _get_local_config()

--- a/app/config/__init__.py
+++ b/app/config/__init__.py
@@ -12,6 +12,7 @@ def get_config():
     default = _get_default_config()
     _parse_env_vars(default)
     local = _get_local_config()
+    _parse_env_vars(local)
     _update_dict(default, local)
     return default
 

--- a/app/config/local_testing.yml
+++ b/app/config/local_testing.yml
@@ -2,4 +2,4 @@ flask:
   env: test
 app:
   hawk_enabled: True
-  database_url: postgresql://postgres:postgres@postgres/postgres
+  database_url: $ENV{DATABASE_URL, postgresql://postgres@postgres/postgres}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
 
   postgres:
     image: "postgres"
+    env_file:
+      - ${ENV_FILE:-.env}
     ports:
       - "5433:5432"
   redis:

--- a/requirements.in
+++ b/requirements.in
@@ -21,6 +21,7 @@ pycountry==19.8.18
 pytest-cov==2.8.1
 pytest-mock==2.0.0
 pytest==5.3.5
+python-dotenv==0.11.0
 pyyaml==5.3
 redis==3.4.1
 requests-oauthlib==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@
 #    pip-compile --output-file=requirements.txt requirements.in
 #
 appdirs==1.4.3            # via black
+appnope==0.1.0            # via ipython
 argh==0.26.2
 attrs==19.3.0             # via black, pytest
 babel==2.8.0              # via flask-babelex
@@ -76,6 +77,7 @@ pytest-cov==2.8.1
 pytest-mock==2.0.0
 pytest==5.3.5
 python-dateutil==2.8.1    # via freezegun, pandas
+python-dotenv==0.11.0
 pytz==2019.3              # via babel, pandas
 pyyaml==5.3
 redis==3.4.1


### PR DESCRIPTION
At the moment running pytest locally reads config variables from local_testing.yml and does not allow these to be overriden. This is necessary if you want to customise the database connection string for example. 

This PR allows the .env file to be parsed if the `USE_DOTENV` variable is set to true (automatically done in a new makefile command called `run_tests_local`).

This PR also addresses a recent change in the offical Postgres docker image which means a database password has to be explicitly passed to the container otherwise it doesn't start.